### PR TITLE
Update script for automated build/install of RPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Makemkv-Spec-for-Fedora
+# MakeMKV-Spec-for-Fedora
 
-This is for the spec file to be able to create SRPMS and RPMs of Makemkv for Fedora. The makemkv rpms are build with mock.
+This is for the spec file to be able to create SRPMs and RPMs of MakeMKV for Fedora. The MakeMKV RPMs are built with [mock](https://github.com/rpm-software-management/mock/).
 
 - Install the rpmdevtools and mock packages
 - Add yourself to the "mock" group, log out, log in again
-- Setup rpmfusion repo (acc. <https://rpmfusion.org/Configuration>)
+- Setup [RPM Fusion](https://rpmfusion.org/Configuration) repository
 
   ```bash
-  sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+  sudo dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
   ```
 
 - Setup rpmfusion for mock
@@ -22,6 +22,35 @@ This is for the spec file to be able to create SRPMS and RPMs of Makemkv for Fed
   git clone https://github.com/djotaku/Makemkv-Spec-for-Fedora.git
   cd Makemkv-Spec-for-Fedora
   ```
+
+- Build and Install the RPM package
+
+  This will also pull the current beta key from the MakeMKV website and write it to the configuration file for registration.
+
+  ```bash
+  chmod +x update.sh
+  ./update.sh
+  ```
+
+## Updating MakeMKV
+
+For future updates of MakeMKV, run the update script (provided this repository was updated for the updated version).
+
+ ```bash
+ ./update.sh
+ ```
+
+## Updating the Beta Key
+
+In case the Key runs out before there is a new update, you can also disable building and installing the RPM to only update the key by using the `--nobuild` argument
+
+ ```bash
+ ./update.sh --nobuild
+ ```
+
+## Deprecated steps
+
+**Note:** These steps are ***not*** required anymore, as they have been integrated into the aforementioned update script. These are purely for reference in case you run into issues with the script (change version numbers accordingly).
 
 - Download the makemkv bin and oss tarballs
 

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+if   [ "$1" != "nobuild" ] \
+  && [ "$1" != "n" ] \
+  && [ "$1" != "--nobuild" ]; then
+
+	git pull --ff-only
+	
+	spectool -g makemkv.spec
+	
+	if [ "$1" == "frel" ] && [ "$2" != "" ]; then
+		frel=$2
+		echo "Fedora Release version specified. Using $frel."
+	else
+		frel=$(rpm -E %fedora)
+		echo "No Fedora Release version specified. Using default $frel."
+	fi;
+
+	# delimited by spaces, every space is a new "field" for cut, hence field 9 for the version/release
+	mver=$(cat makemkv.spec | grep Version\: | cut -d" " -f9)
+	rver=$(cat makemkv.spec | grep Release\: | cut -d" " -f9 | sed -e 's/%{?dist}//')
+	
+	mock -r fedora-$frel-x86_64-rpmfusion_nonfree --sources=. --spec=makemkv.spec
+	
+	cp /var/lib/mock/fedora-$frel-x86_64/result/makemkv-$mver-$rver.fc$frel.*.rpm .
+	echo "Copied RPM to current directory. Enter sudo-password to install using DNF. Press Ctrl-c to cancel installation."
+	sudo dnf install makemkv-$mver-$rver.fc$frel.x86_64.rpm
+else
+	echo "--nobuild argument provided - updating key only";
+fi;
+
+# extract current beta "license" key from the buy website and put it in the settings file
+if [ ! -f ~/.MakeMKV/settings.conf ]; then
+	echo "CREATE settings.conf using current beta key."
+	mkdir -p ~/.MakeMKV
+	echo "app_Key = \"$(curl https://www.makemkv.com/buy/ | grep \<code\> | sed -e "s/<code>//; s/<\/code>//")\"" > ~/.MakeMKV/settings.conf
+else
+	echo "UPDATE settings.conf using current beta key."
+	sed -i "s/^app_Key.*/app_Key = \"$(curl https://www.makemkv.com/buy/ | grep \<code\> | sed -e "s/<code>//; s/<\/code>//")\"/" ~/.MakeMKV/settings.conf
+fi;
+
+echo "All done!"


### PR DESCRIPTION
I'm lazy, so I like to automate stuff for the future :) So here we go:

* Always updates the license key, as chances are it has run out by the time there is an update.
* Optional argument `n`/`nobuild`/`--nobuild` to suppress building and installing of the package as to only update the key.*
* Optional `frel` override for Fedora Release version. Useful for testing future release builds (rawhide untested).
* RPM installation can be skipped by simply cancelling the `sudo` prompt.

Note: This does *not* (yet?) do the required steps of installing RPM Fusion and `mock-rpmfusion`, since these are one-time operations. This *can* be easily added, but I'm not sure it's worth the bloat.

*Could also make the build optional by providing an argument (`b`/`build`/`--build`), i.e. only update key when no argument is provided. I'm not sure which use-case happens more often (since this is my first time installing/using MakeMKV).

Thoughts?

Also updated the README accordingly.