### PR TITLE
Update 1.16.5

### DIFF
--- a/makemkv.spec
+++ b/makemkv.spec
@@ -9,7 +9,7 @@
 %global __requires_exclude ^lib(%{_privatelibs})\\.so.*
 
 Name:           makemkv
-Version:        1.16.3
+Version:        1.16.5
 Release:        1%{?dist}
 Summary:        A format converter ("transcoder") for proprietary media
 
@@ -94,7 +94,10 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 
 
 %changelog
-* Tue Apr 13 2021 Tarulia <notarealemail@gmail.com> - 1.16.3
+* Tue Jan 25 2022 Tarulia <mihawk.90+git@googlemail.com> - 1.16.5-1
+- Updated to latest release
+
+* Tue Apr 13 2021 Tarulia <mihawk.90+git@googlemail.com> - 1.16.3-1
 - Updated to latest release
 
 * Fri Dec 27 2019 Adrian Freihofer <adrian.freihofer@gmail.com> - 1.14.7-1

--- a/update.sh
+++ b/update.sh
@@ -33,10 +33,17 @@ fi;
 if [ ! -f ~/.MakeMKV/settings.conf ]; then
 	echo "CREATE settings.conf using current beta key."
 	mkdir -p ~/.MakeMKV
-	echo "app_Key = \"$(curl https://www.makemkv.com/buy/ | grep \<code\> | sed -e "s/<code>//; s/<\/code>//")\"" > ~/.MakeMKV/settings.conf
+	echo "app_Key = \"$(curl "https://forum.makemkv.com/forum/viewtopic.php?f=5&t=1053" \
+	| grep \<code\> \
+	| sed -e "s/.*<code>//; s/<\/code>.*//")\"" \
+	> ~/.MakeMKV/settings.conf
+
 else
 	echo "UPDATE settings.conf using current beta key."
-	sed -i "s/^app_Key.*/app_Key = \"$(curl https://www.makemkv.com/buy/ | grep \<code\> | sed -e "s/<code>//; s/<\/code>//")\"/" ~/.MakeMKV/settings.conf
+	sed -i "s/^app_Key.*/app_Key = \"$(curl "https://forum.makemkv.com/forum/viewtopic.php?f=5&t=1053" \
+	| grep \<code\> \
+	| sed -e "s/.*<code>//; s/<\/code>.*//")\"/" \
+	~/.MakeMKV/settings.conf
 fi;
 
 echo "All done!"


### PR DESCRIPTION
* also added proper mail to previous changelog
* also added Release-version to changelogs to conform with Fedora
  Packaging guideline's E-V-R notation

---

Updated update.sh:
* Beta-Key is not on the Buy page anymore, so we're using the (always
updated) forum thread instead.